### PR TITLE
Demonstrate the best practice of performing registration

### DIFF
--- a/ObjcVoiceQuickstart/AppDelegate.h
+++ b/ObjcVoiceQuickstart/AppDelegate.h
@@ -7,10 +7,19 @@
 
 #import <UIKit/UIKit.h>
 
+@import PushKit;
+
+@protocol PushKitUpdateDelegate <NSObject>
+
+- (void)credentialsUpdated:(PKPushCredentials *)credentials;
+- (void)credentialsInvalidated;
+- (void)incomingPushReceived:(PKPushPayload *)payload withCompletionHandler:(void (^)(void))completion;
+
+@end
+
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
-
 
 @end
 

--- a/ObjcVoiceQuickstart/AppDelegate.h
+++ b/ObjcVoiceQuickstart/AppDelegate.h
@@ -9,7 +9,7 @@
 
 @import PushKit;
 
-@protocol PushKitUpdateDelegate <NSObject>
+@protocol PushKitEventDelegate <NSObject>
 
 - (void)credentialsUpdated:(PKPushCredentials *)credentials;
 - (void)credentialsInvalidated;

--- a/ObjcVoiceQuickstart/AppDelegate.m
+++ b/ObjcVoiceQuickstart/AppDelegate.m
@@ -12,7 +12,7 @@
 
 @interface AppDelegate () <PKPushRegistryDelegate>
 
-@property (nonatomic, weak) id<PushKitUpdateDelegate> pushKitUpdateDelegate;
+@property (nonatomic, weak) id<PushKitEventDelegate> pushKitEventDelegate;
 @property (nonatomic, strong) PKPushRegistry *voipRegistry;
 
 @end
@@ -23,7 +23,7 @@
     NSLog(@"Twilio Voice Version: %@", [TwilioVoice sdkVersion]);
     
     ViewController* viewController = (ViewController*)self.window.rootViewController;
-    self.pushKitUpdateDelegate = viewController;
+    self.pushKitEventDelegate = viewController;
     [self initializePushKit];
     
     return YES;
@@ -62,8 +62,8 @@
     NSLog(@"pushRegistry:didUpdatePushCredentials:forType:");
 
     if ([type isEqualToString:PKPushTypeVoIP]) {
-        if (self.pushKitUpdateDelegate && [self.pushKitUpdateDelegate respondsToSelector:@selector(credentialsUpdated:)]) {
-            [self.pushKitUpdateDelegate credentialsUpdated:credentials];
+        if (self.pushKitEventDelegate && [self.pushKitEventDelegate respondsToSelector:@selector(credentialsUpdated:)]) {
+            [self.pushKitEventDelegate credentialsUpdated:credentials];
         }
     }
 }
@@ -72,8 +72,8 @@
     NSLog(@"pushRegistry:didInvalidatePushTokenForType:");
 
     if ([type isEqualToString:PKPushTypeVoIP]) {
-        if (self.pushKitUpdateDelegate && [self.pushKitUpdateDelegate respondsToSelector:@selector(credentialsInvalidated)]) {
-            [self.pushKitUpdateDelegate credentialsInvalidated];
+        if (self.pushKitEventDelegate && [self.pushKitEventDelegate respondsToSelector:@selector(credentialsInvalidated)]) {
+            [self.pushKitEventDelegate credentialsInvalidated];
         }
     }
 }
@@ -83,9 +83,9 @@ didReceiveIncomingPushWithPayload:(PKPushPayload *)payload
              forType:(NSString *)type {
     NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:");
     
-    if (self.pushKitUpdateDelegate &&
-        [self.pushKitUpdateDelegate respondsToSelector:@selector(incomingPushReceived:withCompletionHandler:)]) {
-        [self.pushKitUpdateDelegate incomingPushReceived:payload withCompletionHandler:nil];
+    if (self.pushKitEventDelegate &&
+        [self.pushKitEventDelegate respondsToSelector:@selector(incomingPushReceived:withCompletionHandler:)]) {
+        [self.pushKitEventDelegate incomingPushReceived:payload withCompletionHandler:nil];
     }
 }
 
@@ -99,9 +99,9 @@ didReceiveIncomingPushWithPayload:(PKPushPayload *)payload
 withCompletionHandler:(void (^)(void))completion {
     NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:");
     
-    if (self.pushKitUpdateDelegate &&
-        [self.pushKitUpdateDelegate respondsToSelector:@selector(incomingPushReceived:withCompletionHandler:)]) {
-        [self.pushKitUpdateDelegate incomingPushReceived:payload withCompletionHandler:completion];
+    if (self.pushKitEventDelegate &&
+        [self.pushKitEventDelegate respondsToSelector:@selector(incomingPushReceived:withCompletionHandler:)]) {
+        [self.pushKitEventDelegate incomingPushReceived:payload withCompletionHandler:completion];
     }
 
     if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 13) {

--- a/ObjcVoiceQuickstart/ViewController.h
+++ b/ObjcVoiceQuickstart/ViewController.h
@@ -7,7 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface ViewController : UIViewController <PushKitUpdateDelegate>
+@interface ViewController : UIViewController <PushKitEventDelegate>
 
 @end
 

--- a/ObjcVoiceQuickstart/ViewController.h
+++ b/ObjcVoiceQuickstart/ViewController.h
@@ -7,8 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface ViewController : UIViewController
-
+@interface ViewController : UIViewController <PushKitUpdateDelegate>
 
 @end
 

--- a/ObjcVoiceQuickstart/ViewController.m
+++ b/ObjcVoiceQuickstart/ViewController.m
@@ -5,6 +5,7 @@
 //  Copyright © 2016-2018 Twilio, Inc. All rights reserved.
 //
 
+#import "AppDelegate.h"
 #import "ViewController.h"
 
 @import AVFoundation;
@@ -20,11 +21,10 @@ static NSString *const kTwimlParamTo = @"to";
 
 NSString * const kCachedDeviceToken = @"CachedDeviceToken";
 
-@interface ViewController () <PKPushRegistryDelegate, TVONotificationDelegate, TVOCallDelegate, CXProviderDelegate, UITextFieldDelegate, AVAudioPlayerDelegate>
+@interface ViewController () <TVONotificationDelegate, TVOCallDelegate, CXProviderDelegate, UITextFieldDelegate, AVAudioPlayerDelegate>
 
 @property (nonatomic, strong) NSString *deviceTokenString;
 
-@property (nonatomic, strong) PKPushRegistry *voipRegistry;
 @property (nonatomic, strong) void(^incomingPushCompletionCallback)(void);
 @property (nonatomic, strong) void(^callKitCompletionCallback)(BOOL);
 @property (nonatomic, strong) TVODefaultAudioDevice *audioDevice;
@@ -56,10 +56,6 @@ NSString * const kCachedDeviceToken = @"CachedDeviceToken";
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-
-    self.voipRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
-    self.voipRegistry.delegate = self;
-    self.voipRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
 
     [self toggleUIState:YES showCallControl:NO];
     self.outgoingValue.delegate = self;
@@ -224,111 +220,77 @@ NSString * const kCachedDeviceToken = @"CachedDeviceToken";
     return YES;
 }
 
-#pragma mark - PKPushRegistryDelegate
-- (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type {
-    NSLog(@"pushRegistry:didUpdatePushCredentials:forType:");
-
-    if ([type isEqualToString:PKPushTypeVoIP]) {
-        const unsigned *tokenBytes = [credentials.token bytes];
-        self.deviceTokenString = [NSString stringWithFormat:@"<%08x %08x %08x %08x %08x %08x %08x %08x>",
-                                  ntohl(tokenBytes[0]), ntohl(tokenBytes[1]), ntohl(tokenBytes[2]),
-                                  ntohl(tokenBytes[3]), ntohl(tokenBytes[4]), ntohl(tokenBytes[5]),
-                                  ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
-        NSString *accessToken = [self fetchAccessToken];
-        
-        NSString *cachedDeviceToken = [[NSUserDefaults standardUserDefaults] objectForKey:kCachedDeviceToken];
-        if (![cachedDeviceToken isEqualToString:self.deviceTokenString]) {
-            cachedDeviceToken = self.deviceTokenString;
-            
-            /*
-             * Perform registration if a new device token is detected.
-             */
-            [TwilioVoice registerWithAccessToken:accessToken
-                                     deviceToken:cachedDeviceToken
-                                      completion:^(NSError *error) {
-                 if (error) {
-                     NSLog(@"An error occurred while registering: %@", [error localizedDescription]);
-                 }
-                 else {
-                     NSLog(@"Successfully registered for VoIP push notifications.");
-                     
-                     /*
-                      * Save the device token after successfully registered for future registration requests
-                      * in case the token format is changed in future iOS releases, which could potentially
-                      * break the registration process and the incoming capability.
-                      */
-                     [[NSUserDefaults standardUserDefaults] setObject:cachedDeviceToken forKey:kCachedDeviceToken];
-                 }
-             }];
-        }
-    }
-}
-
-- (void)pushRegistry:(PKPushRegistry *)registry didInvalidatePushTokenForType:(PKPushType)type {
-    NSLog(@"pushRegistry:didInvalidatePushTokenForType:");
-
-    if ([type isEqualToString:PKPushTypeVoIP]) {
-        NSString *accessToken = [self fetchAccessToken];
-
-        [TwilioVoice unregisterWithAccessToken:accessToken
-                                   deviceToken:self.deviceTokenString
-                                    completion:^(NSError * _Nullable error) {
-            if (error) {
-                NSLog(@"An error occurred while unregistering: %@", [error localizedDescription]);
-            }
-            else {
-                NSLog(@"Successfully unregistered for VoIP push notifications.");
-            }
-        }];
-
-        self.deviceTokenString = nil;
-    }
-}
-
-/**
- * Try using the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method if
- * your application is targeting iOS 11. According to the docs, this delegate method is deprecated by Apple.
- */
-- (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type {
-    NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:");
-    if ([type isEqualToString:PKPushTypeVoIP]) {
-        
-        // The Voice SDK will use main queue to invoke `cancelledCallInviteReceived:error` when delegate queue is not passed
-        if (![TwilioVoice handleNotification:payload.dictionaryPayload delegate:self delegateQueue:nil]) {
-            NSLog(@"This is not a valid Twilio Voice notification.");
-        }
-    }
-}
-
-/**
- * This delegate method is available on iOS 11 and above. Call the completion handler once the
- * notification payload is passed to the `TwilioVoice.handleNotification()` method.
- */
-- (void)pushRegistry:(PKPushRegistry *)registry
-didReceiveIncomingPushWithPayload:(PKPushPayload *)payload
-             forType:(PKPushType)type
-withCompletionHandler:(void (^)(void))completion {
-    NSLog(@"pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:");
-
-    // Save for later when the notification is properly handled.
-    self.incomingPushCompletionCallback = completion;
-
+#pragma mark - PushKitUpdateDelegate
+- (void)credentialsUpdated:(PKPushCredentials *)credentials {
+    const unsigned *tokenBytes = [credentials.token bytes];
+    self.deviceTokenString = [NSString stringWithFormat:@"<%08x %08x %08x %08x %08x %08x %08x %08x>",
+                              ntohl(tokenBytes[0]), ntohl(tokenBytes[1]), ntohl(tokenBytes[2]),
+                              ntohl(tokenBytes[3]), ntohl(tokenBytes[4]), ntohl(tokenBytes[5]),
+                              ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
+    NSString *accessToken = [self fetchAccessToken];
     
-    if ([type isEqualToString:PKPushTypeVoIP]) {
-        // The Voice SDK will use main queue to invoke `cancelledCallInviteReceived:error` when delegate queue is not passed
-        if (![TwilioVoice handleNotification:payload.dictionaryPayload delegate:self delegateQueue:nil]) {
-            NSLog(@"This is not a valid Twilio Voice notification.");
-        }
+    NSString *cachedDeviceToken = [[NSUserDefaults standardUserDefaults] objectForKey:kCachedDeviceToken];
+    if (![cachedDeviceToken isEqualToString:self.deviceTokenString]) {
+        cachedDeviceToken = self.deviceTokenString;
+        
+        /*
+         * Perform registration if a new device token is detected.
+         */
+        [TwilioVoice registerWithAccessToken:accessToken
+                                 deviceToken:cachedDeviceToken
+                                  completion:^(NSError *error) {
+             if (error) {
+                 NSLog(@"An error occurred while registering: %@", [error localizedDescription]);
+             }
+             else {
+                 NSLog(@"Successfully registered for VoIP push notifications.");
+                 
+                 /*
+                  * Save the device token after successfully registered for future registration requests
+                  * in case the token format is changed in future iOS releases, which could potentially
+                  * break the registration process and the incoming capability.
+                  */
+                 [[NSUserDefaults standardUserDefaults] setObject:cachedDeviceToken forKey:kCachedDeviceToken];
+             }
+         }];
     }
-    if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion < 13) {
-        // Save for later when the notification is properly handled.
-        self.incomingPushCompletionCallback = completion;
-    } else {
-        /**
-        * The Voice SDK processes the call notification and returns the call invite synchronously. Report the incoming call to
-        * CallKit and fulfill the completion before exiting this callback method.
-        */
-        completion();
+}
+
+- (void)credentialsInvalidated {
+    NSString *accessToken = [self fetchAccessToken];
+
+    [TwilioVoice unregisterWithAccessToken:accessToken
+                               deviceToken:self.deviceTokenString
+                                completion:^(NSError *error) {
+        if (error) {
+            NSLog(@"An error occurred while unregistering: %@", [error localizedDescription]);
+        }
+        else {
+            NSLog(@"Successfully unregistered for VoIP push notifications.");
+        }
+    }];
+
+    self.deviceTokenString = nil;
+    [[NSUserDefaults standardUserDefaults] setObject:nil forKey:kCachedDeviceToken];
+}
+
+- (void)incomingPushReceived:(PKPushPayload *)payload withCompletionHandler:(void (^)(void))completion {
+    // The Voice SDK will use main queue to invoke `cancelledCallInviteReceived:error` when delegate queue is not passed
+    if (![TwilioVoice handleNotification:payload.dictionaryPayload delegate:self delegateQueue:nil]) {
+        NSLog(@"This is not a valid Twilio Voice notification.");
+    }
+    
+    if (completion) {
+        if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion < 13) {
+            // Save for later when the notification is properly handled.
+            self.incomingPushCompletionCallback = completion;
+        } else {
+            /*
+             * The Voice SDK processes the call notification and returns the call invite synchronously.
+             * Report the incoming call to CallKit and fulfill the completion before exiting this callback method.
+             */
+            completion();
+        }
     }
 }
 

--- a/ObjcVoiceQuickstart/ViewController.m
+++ b/ObjcVoiceQuickstart/ViewController.m
@@ -239,28 +239,28 @@ NSString * const kCachedDeviceToken = @"CachedDeviceToken";
         NSString *cachedDeviceToken = [[NSUserDefaults standardUserDefaults] objectForKey:kCachedDeviceToken];
         if (![cachedDeviceToken isEqualToString:self.deviceTokenString]) {
             cachedDeviceToken = self.deviceTokenString;
+            
+            /*
+             * Perform registration if a new device token is detected.
+             */
+            [TwilioVoice registerWithAccessToken:accessToken
+                                     deviceToken:cachedDeviceToken
+                                      completion:^(NSError *error) {
+                 if (error) {
+                     NSLog(@"An error occurred while registering: %@", [error localizedDescription]);
+                 }
+                 else {
+                     NSLog(@"Successfully registered for VoIP push notifications.");
+                     
+                     /*
+                      * Save the device token after successfully registered for future registration requests
+                      * in case the token format is changed in future iOS releases, which could potentially
+                      * break the registration process and the incoming capability.
+                      */
+                     [[NSUserDefaults standardUserDefaults] setObject:cachedDeviceToken forKey:kCachedDeviceToken];
+                 }
+             }];
         }
-
-        /*
-         * Use the device token that was previously used in a successful registration.
-         */
-        [TwilioVoice registerWithAccessToken:accessToken
-                                 deviceToken:cachedDeviceToken
-                                  completion:^(NSError *error) {
-             if (error) {
-                 NSLog(@"An error occurred while registering: %@", [error localizedDescription]);
-             }
-             else {
-                 NSLog(@"Successfully registered for VoIP push notifications.");
-                 
-                 /*
-                  * Save the device token after successfully registered in case the token format
-                  * is changed in future iOS releases, which could potentially break the registration
-                  * process and the incoming capability.
-                  */
-                 [[NSUserDefaults standardUserDefaults] setObject:cachedDeviceToken forKey:kCachedDeviceToken];
-             }
-         }];
     }
 }
 

--- a/ObjcVoiceQuickstart/ViewController.m
+++ b/ObjcVoiceQuickstart/ViewController.m
@@ -220,7 +220,7 @@ NSString * const kCachedDeviceToken = @"CachedDeviceToken";
     return YES;
 }
 
-#pragma mark - PushKitUpdateDelegate
+#pragma mark - PushKitEventDelegate
 - (void)credentialsUpdated:(PKPushCredentials *)credentials {
     const unsigned *tokenBytes = [credentials.token bytes];
     self.deviceTokenString = [NSString stringWithFormat:@"<%08x %08x %08x %08x %08x %08x %08x %08x>",
@@ -269,7 +269,7 @@ NSString * const kCachedDeviceToken = @"CachedDeviceToken";
     }];
 
     self.deviceTokenString = nil;
-    [[NSUserDefaults standardUserDefaults] setObject:nil forKey:kCachedDeviceToken];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedDeviceToken];
 }
 
 - (void)incomingPushReceived:(PKPushPayload *)payload withCompletionHandler:(void (^)(void))completion {

--- a/ObjcVoiceQuickstart/ViewController.m
+++ b/ObjcVoiceQuickstart/ViewController.m
@@ -246,9 +246,7 @@ NSString * const kCachedDeviceToken = @"CachedDeviceToken";
                  NSLog(@"Successfully registered for VoIP push notifications.");
                  
                  /*
-                  * Save the device token after successfully registered for future registration requests
-                  * in case the token format is changed in future iOS releases, which could potentially
-                  * break the registration process and the incoming capability.
+                  * Save the device token after successfully registered.
                   */
                  [[NSUserDefaults standardUserDefaults] setObject:cachedDeviceToken forKey:kCachedDeviceToken];
              }

--- a/SwiftVoiceQuickstart/AppDelegate.swift
+++ b/SwiftVoiceQuickstart/AppDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 import TwilioVoice
 import PushKit
 
-protocol PushKitUpdateDelegate: AnyObject {
+protocol PushKitEventDelegate: AnyObject {
     func credentialsUpdated(credentials: PKPushCredentials) -> Void
     func credentialsInvalidated() -> Void
     func incomingPushReceived(payload: PKPushPayload) -> Void
@@ -20,15 +20,14 @@ protocol PushKitUpdateDelegate: AnyObject {
 class AppDelegate: UIResponder, UIApplicationDelegate, PKPushRegistryDelegate {
 
     var window: UIWindow?
-    var pushKitUpdateDelegate: PushKitUpdateDelegate?
+    var pushKitEventDelegate: PushKitEventDelegate?
     var voipRegistry = PKPushRegistry.init(queue: DispatchQueue.main)
-    var viewController: ViewController?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         NSLog("Twilio Voice Version: %@", TwilioVoice.sdkVersion())
         
-        self.viewController = UIApplication.shared.windows.first?.rootViewController as? ViewController
-        self.pushKitUpdateDelegate = self.viewController
+        let viewController = UIApplication.shared.windows.first?.rootViewController as? ViewController
+        self.pushKitEventDelegate = viewController
         initializePushKit()
 
         return true
@@ -65,7 +64,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, PKPushRegistryDelegate {
     func pushRegistry(_ registry: PKPushRegistry, didUpdate credentials: PKPushCredentials, for type: PKPushType) {
         NSLog("pushRegistry:didUpdatePushCredentials:forType:")
         
-        if let delegate = self.pushKitUpdateDelegate {
+        if let delegate = self.pushKitEventDelegate {
             delegate.credentialsUpdated(credentials: credentials)
         }
     }
@@ -73,7 +72,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, PKPushRegistryDelegate {
     func pushRegistry(_ registry: PKPushRegistry, didInvalidatePushTokenFor type: PKPushType) {
         NSLog("pushRegistry:didInvalidatePushTokenForType:")
         
-        if let delegate = self.pushKitUpdateDelegate {
+        if let delegate = self.pushKitEventDelegate {
             delegate.credentialsInvalidated()
         }
     }
@@ -85,7 +84,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, PKPushRegistryDelegate {
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType) {
         NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:")
         
-        if let delegate = self.pushKitUpdateDelegate {
+        if let delegate = self.pushKitEventDelegate {
             delegate.incomingPushReceived(payload: payload)
         }
     }
@@ -97,7 +96,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, PKPushRegistryDelegate {
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
         NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:completion:")
 
-        if let delegate = self.pushKitUpdateDelegate {
+        if let delegate = self.pushKitEventDelegate {
             delegate.incomingPushReceived(payload: payload, completion: completion)
         }
         

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -229,9 +229,7 @@ class ViewController: UIViewController, TVONotificationDelegate, TVOCallDelegate
                     NSLog("Successfully registered for VoIP push notifications.")
                     
                     /*
-                     * Save the device token after successfully registered for future registration requests
-                     * in case the token format is changed in future iOS releases, which could potentially
-                     * break the registration process and the incoming capability.
+                     * Save the device token after successfully registered.
                      */
                     userDefaults.set(cachedDeviceToken, forKey: kCachedDeviceToken)
                 }

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -27,8 +27,6 @@ class ViewController: UIViewController, TVONotificationDelegate, TVOCallDelegate
     @IBOutlet weak var callControlView: UIView!
     @IBOutlet weak var muteSwitch: UISwitch!
     @IBOutlet weak var speakerSwitch: UISwitch!
-    
-    var deviceTokenString: String?
 
     var incomingPushCompletionCallback: (()->Swift.Void?)? = nil
 
@@ -235,12 +233,10 @@ class ViewController: UIViewController, TVONotificationDelegate, TVOCallDelegate
                 }
             }
         }
-
-        self.deviceTokenString = deviceToken
     }
     
     func credentialsInvalidated() {
-        guard let deviceToken = deviceTokenString, let accessToken = fetchAccessToken() else {
+        guard let deviceToken = UserDefaults.standard.string(forKey: kCachedDeviceToken), let accessToken = fetchAccessToken() else {
             return
         }
         
@@ -252,7 +248,6 @@ class ViewController: UIViewController, TVONotificationDelegate, TVOCallDelegate
             }
         }
         
-        self.deviceTokenString = nil
         UserDefaults.standard.removeObject(forKey: kCachedDeviceToken)
     }
     

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -230,24 +230,24 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         var cachedDeviceToken = userDefaults.string(forKey: kCachedDeviceToken)
         if (cachedDeviceToken == nil || cachedDeviceToken != deviceToken) {
             cachedDeviceToken = deviceToken
-        }
-
-        /*
-         * Use the device token that was previously used in a successful registration.
-         */
-        TwilioVoice.register(withAccessToken: accessToken, deviceToken: cachedDeviceToken!) { (error) in
-            if let error = error {
-                NSLog("An error occurred while registering: \(error.localizedDescription)")
-            }
-            else {
-                NSLog("Successfully registered for VoIP push notifications.")
-                
-                /*
-                 * Save the device token after successfully registered in case the token format
-                 * is changed in future iOS releases, which could potentially break the registration
-                 * process and the incoming capability.
-                 */
-                userDefaults.set(cachedDeviceToken, forKey: kCachedDeviceToken)
+            
+            /*
+             * Perform registration if a new device token is detected.
+             */
+            TwilioVoice.register(withAccessToken: accessToken, deviceToken: cachedDeviceToken!) { (error) in
+                if let error = error {
+                    NSLog("An error occurred while registering: \(error.localizedDescription)")
+                }
+                else {
+                    NSLog("Successfully registered for VoIP push notifications.")
+                    
+                    /*
+                     * Save the device token after successfully registered for future registration requests
+                     * in case the token format is changed in future iOS releases, which could potentially
+                     * break the registration process and the incoming capability.
+                     */
+                    userDefaults.set(cachedDeviceToken, forKey: kCachedDeviceToken)
+                }
             }
         }
 

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -19,7 +19,7 @@ let twimlParamTo = "to"
 
 let kCachedDeviceToken = "CachedDeviceToken"
 
-class ViewController: UIViewController, TVONotificationDelegate, TVOCallDelegate, CXProviderDelegate, UITextFieldDelegate, AVAudioPlayerDelegate, PushKitUpdateDelegate {
+class ViewController: UIViewController, TVONotificationDelegate, TVOCallDelegate, CXProviderDelegate, UITextFieldDelegate, AVAudioPlayerDelegate, PushKitEventDelegate {
 
     @IBOutlet weak var placeCallButton: UIButton!
     @IBOutlet weak var iconView: UIImageView!
@@ -206,7 +206,7 @@ class ViewController: UIViewController, TVONotificationDelegate, TVOCallDelegate
         return true
     }
     
-    // MARK: PushKitUpdateDelegate
+    // MARK: PushKitEventDelegate
     func credentialsUpdated(credentials: PKPushCredentials) {
         guard let accessToken = fetchAccessToken() else {
             return
@@ -253,7 +253,7 @@ class ViewController: UIViewController, TVONotificationDelegate, TVOCallDelegate
         }
         
         self.deviceTokenString = nil
-        UserDefaults.standard.set(nil, forKey: kCachedDeviceToken)
+        UserDefaults.standard.removeObject(forKey: kCachedDeviceToken)
     }
     
     func incomingPushReceived(payload: PKPushPayload) {
@@ -270,7 +270,7 @@ class ViewController: UIViewController, TVONotificationDelegate, TVOCallDelegate
             self.incomingPushCompletionCallback = completion
         }
     }
-    
+
     func incomingPushHandled() {
         if let completion = self.incomingPushCompletionCallback {
             completion()


### PR DESCRIPTION
The changes in this PR demonstrate the best practice of how an application should perform registration in order to subscribe for incoming call push notifications.

- Move `PkPushRegistry` instance initialization and `PkPushRegistryDelegate` methods to `AppDelegate`. This ensures that PushKit is set up each time the app is launched and push notifications can be received by the application.
  - Events of the `PkPushRegistryDelegate` protocol will be sent to the view-controller via the `PushKitEventDelegate` protocol. This could be implemented in the best place based on the app logic.
- Upon receiving the `didUpdatePushCredentials:` callback, the app can use the cached device token that was saved in a previous successful registration and only call `TwilioVoice.register()` only when the device token has been updated.
