### PR TITLE
Updates for Voice iOS 5.1.2 release

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'VoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 5.1.1'
+  pod 'TwilioVoice', '~> 5.1.2'
   use_frameworks!
   
   target 'SwiftVoiceQuickstart' do


### PR DESCRIPTION
### 5.1.2

* Programmable Voice iOS SDK 5.1.2 [[Carthage]](https://www.twilio.com/docs/voice/voip-sdk/ios#carthage), [[Cocoapods]](https://www.twilio.com/docs/voice/voip-sdk/ios#cocoapods), [[Dynamic Framework]](https://github.com/twilio/twilio-voice-ios/releases/download/5.1.2/TwilioVoice.framework.zip), [[Static Library]](https://github.com/twilio/twilio-voice-ios/releases/download/5.1.2/libTwilioVoice.zip), [[docs]](https://twilio.github.io/twilio-voice-ios/docs/5.1.2/).

Bug Fixes

- Fixed a crash when a canceled call invite is received and the `from` value is `nil`.

### Size Impact for 5.1.2

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 6.0 MB | 12.6 MB
arm64 | 2.8 MB | 6.8 MB
armv7 | 3.0 MB | 5.6 MB