### PR TITLE
Use Voice iOS 5.2.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'VoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 5.1.2'
+  pod 'TwilioVoice', '~> 5.2.0'
   use_frameworks!
   
   target 'SwiftVoiceQuickstart' do


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

Enhancements

- Attempts to re-establish the media connection will be done preemptively if no media flow is detected for 3 seconds.
- Media connecion of an ongoing `Call` switches to a lower cost network when available.
- Proper data types are added to the Insights event payload.

Bug Fixes

- Fixed a crash when a canceled call invite is received but the `from` value is `nil`.

Things to Note

- Since media and signaling reconnect are two completely separate processes, it is likely that for a single network change event multiple `[TVOCallDelegate call:isReconnectingWithError:]` and `[TVOCallDelegate callDidReconnect:]` callbacks will be received in the order specified i.e a `[TVOCallDelegate call:isReconnectingWithError:]` callback will always be followed by a `[TVOCallDelegate callDidReconnect:]` callback.

### Size Impact for 5.2.0

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 6.0 MB | 12.7 MB
arm64 | 2.8 MB | 6.9 MB
armv7 | 3.0 MB | 5.6 MB

