### PR TITLE
Made the starter code more "Swifty"

### DIFF
--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -337,8 +337,8 @@ extension ViewController: TVONotificationDelegate {
         NSLog("cancelledCallInviteCanceled:error:, error: \(error.localizedDescription)")
         
         guard let activeCallInvites = activeCallInvites, !activeCallInvites.isEmpty else {
-                NSLog("No pending call invite")
-                return
+            NSLog("No pending call invite")
+            return
         }
         
         let callInvite = activeCallInvites.values.first { invite in invite.callSid == cancelledCallInvite.callSid }


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Made some enhancements to the Starter Project code so that there is a more descriptive structure to the code, as well as some refactoring with use of some more "modern" Swift code. That way, other developers can more easily use (or even copy) some code to their own projects without doing *too* much refactoring themselves. 😉 

The enhancements in detail:

- Removed some unnecessary parentheses and references to `self.` (as most of the time, Swift can infer it itself and the syntax highlighting in Xcode cues for an instance member)
- Removed some unnecessary type annotations (Again, Swift can infer most things and it makes the code more readable and concise)
- Removed `break`s in `switch case` statements (Swift `cases` don't automatically fall through)
- Used `guard` instead of `if` e.g. for early returns (less pyramid of doom 😉)
- Used some functional programming features of Swift (i.e. `.first(where: ...)` finds the first element of a Sequence with a given condition)
- Moved protocol conformance to `extension`s (Improves code structure and makes relations to protocols clearer)
- Improved general structure (moved some methods that support protocol methods to extensions, others that serve user interaction to the `ViewController` class itself, etc.)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
