### PR TITLE
Fix VoIP certificate key extraction instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ Export your VoIP Service Certificate as a .p12 file from Keychain Access.
 
 Extract the certificate and private key from the .p12 file using the `openssl` command. 
 
-    $> openssl pkcs12 -in PATH_TO_YOUR_P12 -nocerts -out key.pem
+    $> openssl pkcs12 -in PATH_TO_YOUR_P12 -nokeys -out cert.pem -nodes
+    $> openssl pkcs12 -in PATH_TO_YOUR_P12 -nocerts -out key.pem -nodes
     $> openssl rsa -in key.pem -out key.pem
-    $> openssl pkcs12 -in PATH_TO_YOUR_P12 -clcerts -nokeys -out cert.pem
 
 Go to the [Push Credentials page](https://www.twilio.com/console/voice/sdks/credentials) and create a new Push Credential. Paste the certificate and private key extracted from your certificate. You must paste the keys in as plaintext:
 


### PR DESCRIPTION
Updated VoIP certificate private/public key extraction instructions to match the instructions for extracting keys from regular push certificates - https://www.twilio.com/docs/notify/configure-ios-push-notifications#create-a-certificate-key. Fixes "unable to load Private Key" when trying to extract the private key during the `openssl rsa` command.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
