### PR TITLE
Use Voice iOS 5.3.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'VoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 5.3.0'
+  pod 'TwilioVoice', '~> 5.3.1'
   use_frameworks!
   
   target 'SwiftVoiceQuickstart' do


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

### 5.3.1

* Programmable Voice iOS SDK 5.3.1 [[Carthage]](https://www.twilio.com/docs/voice/voip-sdk/ios#carthage), [[Cocoapods]](https://www.twilio.com/docs/voice/voip-sdk/ios#cocoapods), [[Dynamic Framework]](https://github.com/twilio/twilio-voice-ios/releases/download/5.3.1/TwilioVoice.framework.zip), [[Static Library]](https://github.com/twilio/twilio-voice-ios/releases/download/5.3.1/libTwilioVoice.zip), [[docs]](https://twilio.github.io/twilio-voice-ios/docs/5.3.1/).

Improvements

- Optimized `[TwilioVoice unregisterWithAccessToken:deviceTokenData:completion:]` by reducing the number of network requests.
- Added background handling support to `[TwilioVoice registerWithAccessToken:deviceTokenData:completion:]` and `[TwilioVoice unregisterWithAccessToken:deviceTokenData:completion:]`. They will now finish execution even when the app is backgrounded.

Size Impact for 5.3.1

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 6.0 MB | 12.7 MB
arm64 | 2.8 MB | 6.9 MB
armv7 | 3.0 MB | 5.7 MB