### PR TITLE
Use the quality warning callback to show newly detected/cleared warnings

### DIFF
--- a/ObjcVoiceQuickstart/Base.lproj/Main.storyboard
+++ b/ObjcVoiceQuickstart/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -89,6 +89,16 @@
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Warnings Raised" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2r-Q4-Duu">
+                                <rect key="frame" x="16" y="20" width="343" height="18"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="343" id="Q5b-8P-pyc"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="121" id="Vm1-db-4g2"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
@@ -97,9 +107,12 @@
                             <constraint firstItem="V5R-Ky-YRW" firstAttribute="top" secondItem="r25-bA-TjD" secondAttribute="bottom" constant="8" id="Cf6-jr-cUl"/>
                             <constraint firstItem="LCr-Ji-S0e" firstAttribute="top" secondItem="V5R-Ky-YRW" secondAttribute="bottom" constant="8" id="JLB-FW-qyu"/>
                             <constraint firstItem="V5R-Ky-YRW" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Sje-sA-ye7"/>
+                            <constraint firstItem="a2r-Q4-Duu" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="16" id="Vdl-O0-maL"/>
                             <constraint firstItem="KbF-3Z-6Zb" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="VeB-Km-SPV"/>
                             <constraint firstItem="KbF-3Z-6Zb" firstAttribute="top" secondItem="Yv2-Ab-jqI" secondAttribute="bottom" constant="24" id="evG-yH-jC4"/>
+                            <constraint firstItem="a2r-Q4-Duu" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="20" id="mVf-Fn-3Mz"/>
                             <constraint firstItem="Yv2-Ab-jqI" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="o83-xB-gqy"/>
+                            <constraint firstItem="a2r-Q4-Duu" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="tDg-UQ-eBv"/>
                             <constraint firstItem="LCr-Ji-S0e" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="xTc-1X-DGJ"/>
                             <constraint firstItem="r25-bA-TjD" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="zyz-9B-31r"/>
                         </constraints>
@@ -110,6 +123,7 @@
                         <outlet property="muteSwitch" destination="viR-NY-T2b" id="fZy-Mo-G3K"/>
                         <outlet property="outgoingValue" destination="KbF-3Z-6Zb" id="Rqf-W7-jY1"/>
                         <outlet property="placeCallButton" destination="V5R-Ky-YRW" id="80v-ij-SXe"/>
+                        <outlet property="qualityWarningsToaster" destination="a2r-Q4-Duu" id="nK2-HT-xCd"/>
                         <outlet property="speakerSwitch" destination="YU7-VZ-8Ys" id="Vdc-12-cQK"/>
                     </connections>
                 </viewController>

--- a/SwiftVoiceQuickstart/Base.lproj/Main.storyboard
+++ b/SwiftVoiceQuickstart/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -89,18 +89,31 @@
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Warnings Raised" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bYe-ax-z7H">
+                                <rect key="frame" x="16" y="20" width="343" height="18"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="18" id="eBr-bt-0dQ"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Uic-jJ-PVN" firstAttribute="top" secondItem="zwV-cd-S0l" secondAttribute="bottom" constant="5" id="0IJ-fk-VDK"/>
                             <constraint firstItem="wqn-ZD-zTx" firstAttribute="width" secondItem="wqn-ZD-zTx" secondAttribute="height" multiplier="1:1" id="3fG-Bb-d0i"/>
+                            <constraint firstItem="bYe-ax-z7H" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="20" id="5oq-vZ-X0n"/>
                             <constraint firstItem="wqn-ZD-zTx" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="7tL-jC-ghz"/>
+                            <constraint firstItem="bYe-ax-z7H" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="MOX-uw-HnX"/>
                             <constraint firstItem="Uic-jJ-PVN" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="TDj-X9-ccD"/>
                             <constraint firstItem="Ruy-Jc-pNi" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Wtn-zO-iEK"/>
+                            <constraint firstItem="bYe-ax-z7H" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="16" id="Xxk-Xy-NAE"/>
                             <constraint firstItem="rhQ-vm-Q9J" firstAttribute="firstBaseline" secondItem="wqn-ZD-zTx" secondAttribute="baseline" constant="42.5" id="ckB-PB-Pwa"/>
                             <constraint firstItem="wqn-ZD-zTx" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-97.5" id="dib-4M-LIF"/>
                             <constraint firstItem="zwV-cd-S0l" firstAttribute="top" secondItem="rhQ-vm-Q9J" secondAttribute="bottom" constant="8" id="iHE-nh-FMY"/>
                             <constraint firstItem="zwV-cd-S0l" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="jUO-8C-BeK"/>
+                            <constraint firstItem="bYe-ax-z7H" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="height" multiplier="343:667" id="qjg-O5-9qH"/>
                             <constraint firstItem="rhQ-vm-Q9J" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="usP-tX-t3X"/>
                             <constraint firstItem="Ruy-Jc-pNi" firstAttribute="top" secondItem="Uic-jJ-PVN" secondAttribute="bottom" constant="8" id="zYm-Ph-T9F"/>
                         </constraints>
@@ -111,6 +124,7 @@
                         <outlet property="muteSwitch" destination="3ee-Gh-QDM" id="d1C-2s-MOF"/>
                         <outlet property="outgoingValue" destination="rhQ-vm-Q9J" id="MSu-Nc-DfV"/>
                         <outlet property="placeCallButton" destination="Uic-jJ-PVN" id="oeG-C0-Aoq"/>
+                        <outlet property="qualityWarningsToaster" destination="bYe-ax-z7H" id="nk7-Fe-Eh1"/>
                         <outlet property="speakerSwitch" destination="PCg-X1-dp2" id="QNC-aA-x2p"/>
                     </connections>
                 </viewController>

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -484,16 +484,13 @@ extension ViewController: TVOCallDelegate {
     }
     
     func qualityWarningsUpdatePopup(_ warnings: Set<NSNumber>, isCleared: Bool) {
-        var popupMessage: String! = "Warnings detected:"
+        var popupMessage: String = "Warnings detected: "
         if isCleared {
-            popupMessage = "Warnings cleared:"
+            popupMessage = "Warnings cleared: "
         }
         
-        for warning in warnings {
-            if let warningName = warningString(TVOCallQualityWarning(rawValue: warning.uintValue)!) {
-                popupMessage = popupMessage + " " + warningName
-            }
-        }
+        let mappedWarnings: [String] = warnings.map { number in warningString(TVOCallQualityWarning(rawValue: number.uintValue)!)}
+        popupMessage += mappedWarnings.joined(separator: ", ")
         
         qualityWarningsToaster.alpha = 0.0
         qualityWarningsToaster.text = popupMessage
@@ -513,20 +510,14 @@ extension ViewController: TVOCallDelegate {
         }
     }
     
-    func warningString(_ warning: TVOCallQualityWarning) -> String! {
+    func warningString(_ warning: TVOCallQualityWarning) -> String {
         switch warning {
-        case .highRtt:
-            return "high-rtt"
-        case .highJitter:
-            return "high-jitter"
-        case .highPacketsLostFraction:
-            return "high-packets-lost-fraction"
-        case .lowMos:
-            return "low-mos"
-        case .constantAudioInputLevel:
-            return "constant-audio-input-level"
-        default:
-            return "Unknown warning"
+        case .highRtt: return "high-rtt"
+        case .highJitter: return "high-jitter"
+        case .highPacketsLostFraction: return "high-packets-lost-fraction"
+        case .lowMos: return "low-mos"
+        case .constantAudioInputLevel: return "constant-audio-input-level"
+        default: return "Unknown warning"
         }
     }
     


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

Note: the changes in this PR use a version of the Voice SDK that is in development.

## Description

This PR uses the `[TVOCallDelegate call:didReceiveQualityWarnings:previousWarnings]` to receive updates about the newly raised or cleared quality warnings and display in the UI.

## Screenshots

A toaster showing a warning detected

<kbd><img width=300px src="https://user-images.githubusercontent.com/16326574/79299153-2a6aea00-7e98-11ea-9ad8-8b69f52e069c.PNG"/></kbd>