### PR TITLE
CLIENT-8135 - Saving registration binding date and time in user defaults

### DIFF
--- a/ObjcVoiceQuickstart/ViewController.m
+++ b/ObjcVoiceQuickstart/ViewController.m
@@ -19,7 +19,7 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
 static NSString *const kIdentity = @"alice";
 static NSString *const kTwimlParamTo = @"to";
 
-static NSInteger const kRegistrationBindingTTL = 365;
+static NSInteger const kRegistrationTTLInDays = 365;
 
 NSString * const kCachedDeviceToken = @"CachedDeviceToken";
 NSString * const kCachedBindingTime = @"CachedBindingTime";
@@ -263,7 +263,7 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
         NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
         
         // Register upon half of the TTL
-        dayComponent.day = kRegistrationBindingTTL / 2;
+        dayComponent.day = kRegistrationTTLInDays / 2;
         
         NSDate *bindingExpirationDate = [[NSCalendar currentCalendar] dateByAddingComponents:dayComponent toDate:lastBindingCreated options:0];
         NSDate *currentDate = [NSDate date];
@@ -366,13 +366,6 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
      */
     
     NSLog(@"cancelledCallInviteReceived:");
-    
-    /**
-     * The TTL of a registration is 1 year. The TTL for registration for this device/identity
-     * pair is reset to 1 year whenever a new registration occurs or a push notification is
-     * sent to this device/identity pair.
-     */
-    [[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:kCachedBindingTime];
     
     TVOCallInvite *callInvite;
     for (NSString *uuid in self.activeCallInvites) {

--- a/ObjcVoiceQuickstart/ViewController.m
+++ b/ObjcVoiceQuickstart/ViewController.m
@@ -18,6 +18,7 @@ static NSString *const kYourServerBaseURLString = <#URL TO YOUR ACCESS TOKEN SER
 static NSString *const kAccessTokenEndpoint = @"/accessToken";
 static NSString *const kIdentity = @"alice";
 static NSString *const kTwimlParamTo = @"to";
+
 static NSInteger const kBindingExpirationIntervalDays = 365;
 
 NSString * const kCachedDeviceToken = @"CachedDeviceToken";
@@ -236,8 +237,12 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
                  
                  // Save the device token after successfully registered.
                  [[NSUserDefaults standardUserDefaults] setObject:cachedDeviceToken forKey:kCachedDeviceToken];
-
-                 // Save the date and time to make sure we register before binding enxpiry of 365 days
+                 
+                 /*
+                  * The twilio registration binding is refreshed for 365 days upon regirstrtion and when a new
+                  * push notification is dispatch.
+                  * Reset the binding date in UserDefaults.
+                  */
                  [[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:kCachedBindingTime];
              }
         }];
@@ -245,8 +250,9 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
 }
 
 /*
- * The twilio registration binding is valid for 365 days. This method checks if binding exists in
- * NSUserDefaults, and if 365 days has been passed it returns true, else returns false.
+ * The twilio registration binding is refreshed for 365 days on twilio notify when a new
+ * push-notification is disptached. This method checks if binding exists in UserDefaults,
+ * and if 365 days has been passed then the method will return true, else false.
  */
 - (BOOL)bindingRequired {
     BOOL bindingRequired = YES;
@@ -282,6 +288,8 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
     }
 
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedDeviceToken];
+        
+    // Remove the cached binding as credentials are invalidated
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCachedBindingTime];
 }
 
@@ -322,6 +330,13 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
 
     NSLog(@"callInviteReceived:");
     
+    /*
+     * The twilio registration binding is refreshed for 365 days upon regirstrtion and when a new
+     * push notification is dispatch.
+     * Reset the binding date in UserDefaults.
+     */
+    [[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:kCachedBindingTime];
+    
     if (callInvite.callerInfo.verified != nil && [callInvite.callerInfo.verified boolValue]) {
         NSLog(@"Call invite received from verified caller number!");
     }
@@ -348,6 +363,13 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
      */
     
     NSLog(@"cancelledCallInviteReceived:");
+    
+    /*
+     * The twilio registration binding is refreshed for 365 days upon regirstrtion and when a new
+     * push notification is dispatch.
+     * Reset the binding date in UserDefaults.
+     */
+    [[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:kCachedBindingTime];
     
     TVOCallInvite *callInvite;
     for (NSString *uuid in self.activeCallInvites) {

--- a/ObjcVoiceQuickstart/ViewController.m
+++ b/ObjcVoiceQuickstart/ViewController.m
@@ -244,15 +244,19 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
     }
 }
 
+/*
+ * The twilio registration binding is valid for 365 days. This method checks if binding exists in
+ * NSUserDefaults, and if 365 days has been passed it returns true, else returns false.
+ */
 - (BOOL)bindingRequired {
     BOOL bindingRequired = YES;
-    NSDate *lastTokenRetrivalTime = [[NSUserDefaults standardUserDefaults] objectForKey:kCachedBindingTime];
+    NSDate *lastBindingCreated = [[NSUserDefaults standardUserDefaults] objectForKey:kCachedBindingTime];
     
-    if (lastTokenRetrivalTime) {
+    if (lastBindingCreated) {
         NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
         dayComponent.day = kBindingExpirationIntervalDays;
         
-        NSDate *bindingExpirationDate = [[NSCalendar currentCalendar] dateByAddingComponents:dayComponent toDate:[NSDate date] options:0];
+        NSDate *bindingExpirationDate = [[NSCalendar currentCalendar] dateByAddingComponents:dayComponent toDate:lastBindingCreated options:0];
         NSDate *currentDate = [NSDate date];
         if ([bindingExpirationDate compare:currentDate] == NSOrderedDescending) {
             bindingRequired = NO;

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -285,21 +285,24 @@ extension ViewController: PushKitEventDelegate {
         }
     }
     
+    /*
+     * The twilio registration binding is valid for 365 days. This method checks if binding exists in
+     * UserDefaults, and if 365 days has been passed it returns true, else returns false.
+     */
     func bindingRequired() -> Bool {
         guard
-            let lastBinding = UserDefaults.standard.object(forKey: kCachedBindingDate)
+            let lastBindingCreated = UserDefaults.standard.object(forKey: kCachedBindingDate)
         else { return true }
         
         let date = Date()
         var components = DateComponents()
         components.setValue(kBindingExpiryDays, for: .day)
-        let expirationDate = Calendar.current.date(byAdding: components, to: lastBinding as! Date)!
+        let expirationDate = Calendar.current.date(byAdding: components, to: lastBindingCreated as! Date)!
 
         if expirationDate.compare(date) == ComparisonResult.orderedDescending {
             return false
-        } else {
-            return true;
         }
+        return true;
     }
     
     func credentialsInvalidated() {


### PR DESCRIPTION
Changing the logic about when app should register -
1. Saving date and time of the last successful registration.
2. Since the registration binding is valid for 365 days, forcing registration if last registration was made > 365 days (cc @idelgado ?) 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
