### PR TITLE
Voice ios 6.1.0

### DIFF
--- a/AudioDeviceExample/ViewController.swift
+++ b/AudioDeviceExample/ViewController.swift
@@ -8,6 +8,8 @@
 import CallKit
 import UIKit
 
+import TwilioVoice
+
 let twimlParamTo = "to"
 
 class ViewController: UIViewController {

--- a/AudioDeviceExample/ViewController.swift
+++ b/AudioDeviceExample/ViewController.swift
@@ -45,7 +45,7 @@ class ViewController: UIViewController {
 
         callKitProvider.setDelegate(self, queue: nil)
         
-        TwilioVoice.audioDevice = audioDevice
+        TwilioVoiceSDK.audioDevice = audioDevice
     }
     
     deinit {
@@ -376,7 +376,7 @@ extension ViewController: CXProviderDelegate {
             builder.uuid = uuid
         }
         
-        let call = TwilioVoice.connect(options: connectOptions, delegate: self)
+        let call = TwilioVoiceSDK.connect(options: connectOptions, delegate: self)
         activeCall = call
         callKitCompletionCallback = completionHandler
     }

--- a/ObjcVoiceQuickstart/AppDelegate.m
+++ b/ObjcVoiceQuickstart/AppDelegate.m
@@ -20,7 +20,7 @@
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    NSLog(@"Twilio Voice Version: %@", [TwilioVoice sdkVersion]);
+    NSLog(@"Twilio Voice Version: %@", [TwilioVoiceSDK sdkVersion]);
     
     ViewController* viewController = (ViewController*)self.window.rootViewController;
     self.pushKitEventDelegate = viewController;
@@ -99,7 +99,7 @@ didReceiveIncomingPushWithPayload:(PKPushPayload *)payload
 
 /**
  * This delegate method is available on iOS 11 and above. Call the completion handler once the
- * notification payload is passed to the `TwilioVoice.handleNotification()` method.
+ * notification payload is passed to the `TwilioVoiceSDK.handleNotification()` method.
  */
 - (void)pushRegistry:(PKPushRegistry *)registry
 didReceiveIncomingPushWithPayload:(PKPushPayload *)payload

--- a/ObjcVoiceQuickstart/ViewController.m
+++ b/ObjcVoiceQuickstart/ViewController.m
@@ -77,7 +77,7 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
      * In this case we've already initialized our own `TVODefaultAudioDevice` instance which we will now set.
      */
     self.audioDevice = [TVODefaultAudioDevice audioDevice];
-    TwilioVoice.audioDevice = self.audioDevice;
+    TwilioVoiceSDK.audioDevice = self.audioDevice;
     
     self.activeCallInvites = [NSMutableDictionary dictionary];
     self.activeCalls = [NSMutableDictionary dictionary];
@@ -227,9 +227,9 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
         /*
          * Perform registration if a new device token is detected.
          */
-        [TwilioVoice registerWithAccessToken:accessToken
-                                 deviceToken:cachedDeviceToken
-                                  completion:^(NSError *error) {
+        [TwilioVoiceSDK registerWithAccessToken:accessToken
+                                    deviceToken:cachedDeviceToken
+                                     completion:^(NSError *error) {
              if (error) {
                  NSLog(@"An error occurred while registering: %@", [error localizedDescription]);
              } else {
@@ -279,9 +279,9 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
 
     NSData *cachedDeviceToken = [[NSUserDefaults standardUserDefaults] objectForKey:kCachedDeviceToken];
     if ([cachedDeviceToken length] > 0) {
-        [TwilioVoice unregisterWithAccessToken:accessToken
-                                   deviceToken:cachedDeviceToken
-                                    completion:^(NSError *error) {
+        [TwilioVoiceSDK unregisterWithAccessToken:accessToken
+                                      deviceToken:cachedDeviceToken
+                                       completion:^(NSError *error) {
             if (error) {
                 NSLog(@"An error occurred while unregistering: %@", [error localizedDescription]);
             } else {
@@ -298,7 +298,7 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
 
 - (void)incomingPushReceived:(PKPushPayload *)payload withCompletionHandler:(void (^)(void))completion {
     // The Voice SDK will use main queue to invoke `cancelledCallInviteReceived:error` when delegate queue is not passed
-    if (![TwilioVoice handleNotification:payload.dictionaryPayload delegate:self delegateQueue:nil]) {
+    if (![TwilioVoiceSDK handleNotification:payload.dictionaryPayload delegate:self delegateQueue:nil]) {
         NSLog(@"This is not a valid Twilio Voice notification.");
     }
     
@@ -327,7 +327,7 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
 - (void)callInviteReceived:(TVOCallInvite *)callInvite {
     
     /**
-     * Calling `[TwilioVoice handleNotification:delegate:]` will synchronously process your notification payload and
+     * Calling `[TwilioVoiceSDK handleNotification:delegate:]` will synchronously process your notification payload and
      * provide you a `TVOCallInvite` object. Report the incoming call to CallKit upon receiving this callback.
      */
 
@@ -777,7 +777,7 @@ previousWarnings:(NSSet<NSNumber *> *)previousWarnings {
         builder.params = @{kTwimlParamTo: strongSelf.outgoingValue.text};
         builder.uuid = uuid;
     }];
-    TVOCall *call = [TwilioVoice connectWithOptions:connectOptions delegate:self];
+    TVOCall *call = [TwilioVoiceSDK connectWithOptions:connectOptions delegate:self];
     if (call) {
         self.activeCall = call;
         self.activeCalls[call.uuid.UUIDString] = call;

--- a/Podfile
+++ b/Podfile
@@ -3,16 +3,16 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'VoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 6.0.2'
+  pod 'TwilioVoice', '~> 6.1.0'
   use_frameworks!
   
   target 'SwiftVoiceQuickstart' do
-    platform :ios, '10.0'
+    platform :ios, '11.0'
     project 'SwiftVoiceQuickstart.xcproject'
   end
 
   target 'ObjCVoiceQuickstart' do
-    platform :ios, '10.0'
+    platform :ios, '11.0'
     project 'ObjCVoiceQuickstart.xcproject'
   end
 

--- a/SwiftVoiceQuickstart/AppDelegate.swift
+++ b/SwiftVoiceQuickstart/AppDelegate.swift
@@ -24,7 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, PKPushRegistryDelegate {
     var voipRegistry = PKPushRegistry.init(queue: DispatchQueue.main)
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        NSLog("Twilio Voice Version: %@", TwilioVoice.sdkVersion())
+        NSLog("Twilio Voice Version: %@", TwilioVoiceSDK.sdkVersion())
         
         let viewController = UIApplication.shared.windows.first?.rootViewController as? ViewController
         self.pushKitEventDelegate = viewController
@@ -99,7 +99,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, PKPushRegistryDelegate {
 
     /**
      * This delegate method is available on iOS 11 and above. Call the completion handler once the
-     * notification payload is passed to the `TwilioVoice.handleNotification()` method.
+     * notification payload is passed to the `TwilioVoiceSDK.handleNotification()` method.
      */
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
         NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:completion:")

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -91,7 +91,7 @@ class ViewController: UIViewController {
          * before performing any other actions with the SDK (such as connecting a Call, or accepting an incoming Call).
          * In this case we've already initialized our own `TVODefaultAudioDevice` instance which we will now set.
          */
-        TwilioVoice.audioDevice = audioDevice
+        TwilioVoiceSDK.audioDevice = audioDevice
     }
 
     func fetchAccessToken() -> String? {
@@ -272,7 +272,7 @@ extension ViewController: PushKitEventDelegate {
         /*
          * Perform registration if a new device token is detected.
          */
-        TwilioVoice.register(accessToken: accessToken, deviceToken: cachedDeviceToken) { error in
+        TwilioVoiceSDK.register(accessToken: accessToken, deviceToken: cachedDeviceToken) { error in
             if let error = error {
                 NSLog("An error occurred while registering: \(error.localizedDescription)")
             } else {
@@ -317,7 +317,7 @@ extension ViewController: PushKitEventDelegate {
         guard let deviceToken = UserDefaults.standard.data(forKey: kCachedDeviceToken),
             let accessToken = fetchAccessToken() else { return }
         
-        TwilioVoice.unregister(accessToken: accessToken, deviceToken: deviceToken) { error in
+        TwilioVoiceSDK.unregister(accessToken: accessToken, deviceToken: deviceToken) { error in
             if let error = error {
                 NSLog("An error occurred while unregistering: \(error.localizedDescription)")
             } else {
@@ -333,12 +333,12 @@ extension ViewController: PushKitEventDelegate {
     
     func incomingPushReceived(payload: PKPushPayload) {
         // The Voice SDK will use main queue to invoke `cancelledCallInviteReceived:error:` when delegate queue is not passed
-        TwilioVoice.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil)
+        TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil)
     }
     
     func incomingPushReceived(payload: PKPushPayload, completion: @escaping () -> Void) {
         // The Voice SDK will use main queue to invoke `cancelledCallInviteReceived:error:` when delegate queue is not passed
-        TwilioVoice.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil)
+        TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil)
         
         if let version = Float(UIDevice.current.systemVersion), version < 13.0 {
             // Save for later when the notification is properly handled.
@@ -779,7 +779,7 @@ extension ViewController: CXProviderDelegate {
             builder.uuid = uuid
         }
         
-        let call = TwilioVoice.connect(options: connectOptions, delegate: self)
+        let call = TwilioVoiceSDK.connect(options: connectOptions, delegate: self)
         activeCall = call
         activeCalls[call.uuid!.uuidString] = call
         callKitCompletionCallback = completionHandler


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

### Enhancements

- Private IP addresses are masked in Release mode for the SDK logs and the `ice-candidate` Insights event payload.
- Private IP addresses will not be masked in `Debug` mode. The `selected-ice-candidate-pair` event will contain private IP address of the local active ICE candidate for debugging purpose in both Release and Debug modes.

### Bug Fixes

- Fixed a bug where caller might not receive the `call:didDisconnectWithError:` callback when the callee hangs up. 
- Fixed a bug where callee was not receiving the `cancelledCallInviteReceived:error:` callback when signaling connection error happens.
- The Voice SDK had the same `TwilioVoice` framework name and the class name. This was causing swift compile time errors when an app tries to access a TwilioVoice framework's class using the module name, e.g. `TwilioVoice.ConnectOptions`. Fixed this issues by renaming the `TwilioVoice` class name to `TwilioVoiceSDK`.

### Size Impact for 6.1.0

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 3.1 MB | 6.9 MB
arm64 | 3.1 MB | 6.9 MB