### PR TITLE
Remove invite object from active-invite array when the call is canceled

### DIFF
--- a/ObjcVoiceQuickstart/ViewController.m
+++ b/ObjcVoiceQuickstart/ViewController.m
@@ -378,6 +378,7 @@ NSString * const kCachedBindingTime = @"CachedBindingTime";
     
     if (callInvite) {
         [self performEndCallActionWithUUID:callInvite.uuid];
+        [self.activeCallInvites removeObjectForKey:callInvite.uuid.UUIDString];
     }
 }
 

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -394,6 +394,7 @@ extension ViewController: NotificationDelegate {
         
         if let callInvite = callInvite {
             performEndCallAction(uuid: callInvite.uuid)
+            self.activeCallInvites.removeValue(forKey: callInvite.uuid.uuidString)
         }
     }
 }


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

### Description

Remove invite object from active-invite array when the call is canceled to avoid a redundant `invite.reject()` call in the CallKit `provider:performEndCallAction:` callback, which could be fired when the user actively rejects the call from the system Call app UI.

Without removing the invite, the `invite.reject()` would result in a `410 Gone` error since in the case of the call being hung up by the remote party the call which the SDK is trying to reject is already gone.

### Validation

Without the updates, the SDK receives a `410 Gone` error after calling `reject()` while the call has been ended (CA1f8acd4e3acb20c8a8966da75c2c5448). No more `reject` and `410 Gone` error after patched (CA4fe1bc8ad364053b987434e6c2afdc24).
