### PR TITLE
(5.x) Use Voice iOS 5.5.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'VoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 5.5.1'
+  pod 'TwilioVoice', '~> 5.5.2'
   use_frameworks!
   
   target 'SwiftVoiceQuickstart' do


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

* Programmable Voice iOS SDK 5.5.2 [[Carthage]](https://www.twilio.com/docs/voice/voip-sdk/ios#carthage), [[Cocoapods]](https://www.twilio.com/docs/voice/voip-sdk/ios#cocoapods), [[Dynamic Framework]](https://github.com/twilio/twilio-voice-ios/releases/download/5.5.2/TwilioVoice.framework.zip), [[Static Library]](https://github.com/twilio/twilio-voice-ios/releases/download/5.5.2/libTwilioVoice.zip), [[docs]](https://twilio.github.io/twilio-voice-ios/docs/5.5.2/).

Bug Fixes

- Fixed a potential crash in the core module where the logger could be accessed after being destroyed by another thread. [#419](https://github.com/twilio/voice-quickstart-ios/issues/419)
- Fixed a bug where caller might not receive the `[TVOCallDelegate call:didDisconnectiWithError:]` callback when callee hangs up.
- Fixed a bug where callee was not receiving the `[TVONotificationDelegate cancelledCallInviteReceived:error:]` callback when signaling connection error happens.

Size Impact for 5.5.2

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 3.0 MB | 6.7 MB
arm64 | 3.0 MB | 6.7 MB