### PR TITLE
Use Voice iOS 6.3.0

### DIFF
--- a/VoiceQuickstart.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceQuickstart.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/twilio/twilio-voice-ios",
         "state": {
           "branch": null,
-          "revision": "9779c5a4132c0e2567b85efb7cb69ca8aba6d43e",
-          "version": "6.2.0"
+          "revision": "075cf26abf9b7e4782600f464b564ae6b5cadc4c",
+          "version": "6.3.0"
         }
       }
     ]


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

Enhancements

- This release is based on Chromium WebRTC 88.
- The simulator `arm64` architecture on Apple Silicon Macs is now available.
- The SDK uses Unified Plan SDP semantics instead of Plan-B.

Known Issues

- Carthage is not currently a supported distribution mechanism for Twilio Voice. Carthage does not currently work with `.xcframeworks` as documented [here](https://github.com/Carthage/Carthage/issues/2890). Once Carthage supports binary `.xcframeworks`, Carthage distribution will be re-added.

Size Impact for 6.3.0

Architecture | Compressed Size | Uncompressed Size
------------ | --------------- | -----------------
arm64 | 3.2 MB | 7.1 MB