### PR TITLE
Use Voice iOS 6.3.1

### DIFF
--- a/VoiceQuickstart.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceQuickstart.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/twilio/twilio-voice-ios",
         "state": {
           "branch": null,
-          "revision": "075cf26abf9b7e4782600f464b564ae6b5cadc4c",
-          "version": "6.3.0"
+          "revision": "299f89b4053fbfb7511751033b41029a42872b56",
+          "version": "6.3.1"
         }
       }
     ]


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

### 6.3.1

* Programmable Voice iOS SDK 6.3.1 [[XCFramework]](https://github.com/twilio/twilio-voice-ios/releases/download/6.3.1/TwilioVoice.xcframework.zip) (checksum: 08e5839eb77d8746baff8b132059f0babfb9e1ed860903553b7d9c02411442af
).

Enhancements

- The Voice SDK now validates full remote domain names while setting up the TLS connection.
- The Voice SDK now uses the maximum timeout value 10 minutes to answer an incoming call.

### Size Impact for 6.3.1

Architecture | Compressed Size | Uncompressed Size
------------ | --------------- | -----------------
arm64 | 3.2 MB | 7.0 MB