### PR TITLE
Instructions to manage push credentials using the Notify Credential Resource API

### DIFF
--- a/Docs/push-credentials-via-notify-api.md
+++ b/Docs/push-credentials-via-notify-api.md
@@ -1,0 +1,29 @@
+## Create Push Credentials via the Notify Credential Resource API
+
+Voice SDK users can manage their Push Credentials in the developer console (**Console > Account > Keys & Credentials > Credentials**). Currently the Push Credential management page only supports the default region (US1). To create or update Push Credentials for AU1 regional usage, developers can use the AU1 endpoint of the Notify public API to manage their Push Credentials. Follow the instructions of the [Credential Resource API](https://www.twilio.com/docs/notify/api/credential-resource) and replace the endpoint with the AU1 API endpoint (https://notify.sydney.au1.twilio.com).
+
+You will also need:
+- APN certificate or FCM key: follow the quickstart instructions ([Android](https://github.com/twilio/voice-quickstart-android#1-generate-google-servicesjson)/[iOS](https://github.com/twilio/voice-quickstart-ios#6-create-a-push-credential-with-your-voip-service-certificate)) to get the platform messaging service credentials
+- Twilio account credentials: find your API auth token for the AU1 region in the developer console. Go to **Console > Account > Keys & Credentials > API keys & tokens** and select **Australia (AU1)** in the dropdown menu.
+
+Example of creating an AU1 Push Credential for iOS:
+
+```
+curl -X POST https://notify.sydney.au1.twilio.com/v1/Credentials \
+--data-urlencode "Type=apn" \
+--data-urlencode "Certificate=$(cat $PATH_OF_CERT_PEM)" \
+--data-urlencode "PrivateKey=$(cat $PATH_OF_KEY_PEM)" \
+--data-urlencode "Sandbox=true" \
+-u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN
+```
+
+To update a Push Credential (CR****):
+
+```
+curl -X POST https://notify.sydney.au1.twilio.com/v1/Credentials/CR**** \
+--data-urlencode "Type=apn" \
+--data-urlencode "Certificate=$(cat $PATH_OF_CERT_PEM)" \
+--data-urlencode "PrivateKey=$(cat $PATH_OF_KEY_PEM)" \
+--data-urlencode "Sandbox=true" \
+-u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN
+```

--- a/Docs/push-credentials-via-notify-api.md
+++ b/Docs/push-credentials-via-notify-api.md
@@ -1,12 +1,12 @@
 ## Create Push Credentials via the Notify Credential Resource API
 
-Voice SDK users can manage their Push Credentials in the developer console (**Console > Account > Keys & Credentials > Credentials**). Currently the Push Credential management page only supports the default region (US1). To create or update Push Credentials for AU1 regional usage, developers can use the AU1 endpoint of the Notify public API to manage their Push Credentials. Follow the instructions of the [Credential Resource API](https://www.twilio.com/docs/notify/api/credential-resource) and replace the endpoint with the AU1 API endpoint (https://notify.sydney.au1.twilio.com).
+Voice SDK users can manage their Push Credentials in the developer console (**Console > Account > Keys & Credentials > Credentials**). Currently the Push Credential management page only supports the default region (US1). To create or update Push Credentials for other regional (i.e. Australia) usage, developers can use the Notify public API to manage their Push Credentials. Follow the instructions of the [Credential Resource API](https://www.twilio.com/docs/notify/api/credential-resource) and replace the endpoint with the regional endpoint, for example https://notify.sydney.au1.twilio.com for the Australia region.
 
 You will also need:
 - APN certificate or FCM key: follow the quickstart instructions ([Android](https://github.com/twilio/voice-quickstart-android#1-generate-google-servicesjson)/[iOS](https://github.com/twilio/voice-quickstart-ios#6-create-a-push-credential-with-your-voip-service-certificate)) to get the platform messaging service credentials
-- Twilio account credentials: find your API auth token for the AU1 region in the developer console. Go to **Console > Account > Keys & Credentials > API keys & tokens** and select **Australia (AU1)** in the dropdown menu.
+- Twilio account credentials: find your API auth token for the specific region in the developer console. Go to **Console > Account > Keys & Credentials > API keys & tokens** and select the region in the dropdown menu.
 
-Example of creating an AU1 Push Credential for iOS:
+Example of creating an `AU1` Push Credential for iOS:
 
 ```
 curl -X POST https://notify.sydney.au1.twilio.com/v1/Credentials \
@@ -17,7 +17,7 @@ curl -X POST https://notify.sydney.au1.twilio.com/v1/Credentials \
 -u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN
 ```
 
-To update a Push Credential (CR****):
+To update a Push Credential (CR****) in `AU1`:
 
 ```
 curl -X POST https://notify.sydney.au1.twilio.com/v1/Credentials/CR**** \

--- a/Docs/push-credentials-via-notify-api.md
+++ b/Docs/push-credentials-via-notify-api.md
@@ -3,10 +3,10 @@
 Voice SDK users can manage their Push Credentials in the developer console (**Console > Account > Keys & Credentials > Credentials**). Currently the Push Credential management page only supports the default region (US1). To create or update Push Credentials for other regional (i.e. Australia) usage, developers can use the Notify public API to manage their Push Credentials. Follow the instructions of the [Credential Resource API](https://www.twilio.com/docs/notify/api/credential-resource) and replace the endpoint with the regional endpoint, for example https://notify.sydney.au1.twilio.com for the Australia region.
 
 You will also need:
-- APN certificate or FCM key: follow the quickstart instructions ([Android](https://github.com/twilio/voice-quickstart-android#1-generate-google-servicesjson)/[iOS](https://github.com/twilio/voice-quickstart-ios#6-create-a-push-credential-with-your-voip-service-certificate)) to get the platform messaging service credentials
+- Apple VoIP Service certificate: follow the [instructions](https://github.com/twilio/voice-quickstart-ios#6-create-a-push-credential-with-your-voip-service-certificate) to get the certificate and key.
 - Twilio account credentials: find your API auth token for the specific region in the developer console. Go to **Console > Account > Keys & Credentials > API keys & tokens** and select the region in the dropdown menu.
 
-Example of creating an `AU1` Push Credential for iOS:
+Example of creating an `AU1` Push Credential for APN:
 
 ```
 curl -X POST https://notify.sydney.au1.twilio.com/v1/Credentials \

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 * [Access Tokens](https://github.com/twilio/voice-quickstart-ios/blob/master/Docs/access-tokens.md) - Using access tokens
 * [Managing Audio Interruptions](https://github.com/twilio/voice-quickstart-ios/blob/master/Docs/managing-audio-interruptions.md) - Managing audio interruptions
 * [Managing Push Credentials](https://github.com/twilio/voice-quickstart-ios/blob/master/Docs/managing-push-credentials.md) - Managing push credentials
+* [Managing Regional Push Credentials using Notify Credential Resource API](https://github.com/twilio/voice-quickstart-ios/blob/master/Docs/push-credentials-via-notify-api.md) - Create or update push credentials for regional usage
 * [More Documentation](#more-documentation) - More documentation related to the Voice iOS SDK
 * [Issues and Support](#issues-and-support) - Filing issues and general support
 


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

- Instruction and sample code showing how to manage Push Credentials (for regional) using the Notify Credential Resource API
- Reference link in the README

Note that this page will be referenced in the changelog when the regional feature is released.