### PR TITLE
Add support for multiple call handling

### DIFF
--- a/SwiftVoiceQuickstart/Base.lproj/Main.storyboard
+++ b/SwiftVoiceQuickstart/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,27 +22,28 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="TwilioLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="wqn-ZD-zTx">
                                 <rect key="frame" x="67.5" y="116" width="240" height="240"/>
                                 <constraints>
+                                    <constraint firstAttribute="width" secondItem="wqn-ZD-zTx" secondAttribute="height" multiplier="1:1" id="3fG-Bb-d0i"/>
                                     <constraint firstAttribute="width" secondItem="wqn-ZD-zTx" secondAttribute="height" multiplier="1:1" id="Ixe-Ao-E58"/>
                                     <constraint firstAttribute="width" constant="240" id="eQS-aZ-GXk"/>
                                 </constraints>
                             </imageView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rhQ-vm-Q9J">
-                                <rect key="frame" x="67.5" y="377" width="240" height="34"/>
+                                <rect key="frame" x="67.5" y="376.5" width="240" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="240" id="7F4-BI-EYe"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uic-jJ-PVN">
-                                <rect key="frame" x="172.5" y="464" width="30" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uic-jJ-PVN">
+                                <rect key="frame" x="172.5" y="463.5" width="30" height="30"/>
                                 <state key="normal" title="Call"/>
                                 <connections>
                                     <action selector="mainButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="oz8-Qi-Loz"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ruy-Jc-pNi">
-                                <rect key="frame" x="67.5" y="502" width="240" height="88"/>
+                                <rect key="frame" x="67.5" y="501.5" width="240" height="88"/>
                                 <subviews>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3ee-Gh-QDM">
                                         <rect key="frame" x="52" y="8" width="49" height="31"/>
@@ -80,7 +81,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dial a client name or phone number. Leaving the field empty results in an automated response." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zwV-cd-S0l">
-                                <rect key="frame" x="59.5" y="419" width="256" height="40"/>
+                                <rect key="frame" x="59.5" y="418.5" width="256" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="hZt-6Q-bpz"/>
                                     <constraint firstAttribute="width" constant="256" id="qsn-tN-Cej"/>
@@ -90,7 +91,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Warnings Raised" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bYe-ax-z7H">
-                                <rect key="frame" x="16" y="20" width="343" height="18"/>
+                                <rect key="frame" x="16" y="40" width="343" height="18"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="18" id="eBr-bt-0dQ"/>
                                 </constraints>
@@ -102,13 +103,11 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Uic-jJ-PVN" firstAttribute="top" secondItem="zwV-cd-S0l" secondAttribute="bottom" constant="5" id="0IJ-fk-VDK"/>
-                            <constraint firstItem="wqn-ZD-zTx" firstAttribute="width" secondItem="wqn-ZD-zTx" secondAttribute="height" multiplier="1:1" id="3fG-Bb-d0i"/>
                             <constraint firstItem="bYe-ax-z7H" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="20" id="5oq-vZ-X0n"/>
                             <constraint firstItem="wqn-ZD-zTx" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="7tL-jC-ghz"/>
                             <constraint firstItem="bYe-ax-z7H" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="MOX-uw-HnX"/>
                             <constraint firstItem="Uic-jJ-PVN" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="TDj-X9-ccD"/>
                             <constraint firstItem="Ruy-Jc-pNi" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Wtn-zO-iEK"/>
-                            <constraint firstItem="bYe-ax-z7H" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="16" id="Xxk-Xy-NAE"/>
                             <constraint firstItem="rhQ-vm-Q9J" firstAttribute="firstBaseline" secondItem="wqn-ZD-zTx" secondAttribute="baseline" constant="42.5" id="ckB-PB-Pwa"/>
                             <constraint firstItem="wqn-ZD-zTx" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-97.5" id="dib-4M-LIF"/>
                             <constraint firstItem="zwV-cd-S0l" firstAttribute="top" secondItem="rhQ-vm-Q9J" secondAttribute="bottom" constant="8" id="iHE-nh-FMY"/>
@@ -133,8 +132,8 @@
             <point key="canvasLocation" x="117.59999999999999" y="118.29085457271366"/>
         </scene>
     </scenes>
+    <color key="tintColor" red="0.8862745098" green="0.1137254902" blue="0.1450980392" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
     <resources>
         <image name="TwilioLogo.png" width="296" height="296"/>
     </resources>
-    <color key="tintColor" red="0.8862745098" green="0.1137254902" blue="0.1450980392" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
 </document>

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -688,9 +688,10 @@ extension ViewController: CXProviderDelegate {
         if let call = activeCalls[action.callUUID.uuidString] {
             call.isOnHold = action.isOnHold
 
-            // Explicitly enable the TVOAudioDevice.
-            // This is workaround for an iOS issue where the `provider(_:didActivate:)` method is not called after un-holding a PSTN call.
-            // https://developer.apple.com/forums/thread/694836
+            /** Explicitly enable the TVOAudioDevice.
+            * This is workaround for an iOS issue where the `provider(_:didActivate:)` method is not called
+            * when un-holding a VoIP call after an ended PSTN call.
+            */ https://developer.apple.com/forums/thread/694836
             if !call.isOnHold {
                 audioDevice.isEnabled = true
                 activeCall = call


### PR DESCRIPTION
## Description
<!-- Describe your Pull Request -->
Add support for handling multiple Voice SDK calls at the same time.

## Breakdown
- Set the [maximumCallGroups](https://developer.apple.com/documentation/callkit/cxproviderconfiguration/1648348-maximumcallgroups) property to "2" to allow swapping between multiple Voice SDK calls.
- Add tracking of the UISwitch states when switching between multiple ongoing calls
- Fix constraint error for the Quality Warning label
- Fix invalid `callIsReconnecting` delegate method name
- Add workaround for an iOS bug when un-holding a VoIP call after an ended PSTN call (https://developer.apple.com/forums/thread/694836)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
