### PR TITLE
Ensure UI is updated on the main thread when denying mic permission and add support for sending DTMF

### DIFF
--- a/AudioDeviceExample/ViewController.swift
+++ b/AudioDeviceExample/ViewController.swift
@@ -133,8 +133,9 @@ class ViewController: UIViewController {
                 self?.performStartCallAction(uuid: uuid, handle: handle)
                 return
             }
-        
-            self?.showMicrophoneAccessRequest(uuid, handle)
+            DispatchQueue.main.async {
+                self?.showMicrophoneAccessRequest(uuid, handle)
+            }
         }
     }
     
@@ -298,6 +299,17 @@ extension ViewController: CXProviderDelegate {
 
         if let call = activeCall {
             call.isMuted = action.isMuted
+            action.fulfill()
+        } else {
+            action.fail()
+        }
+    }
+
+    func provider(_ provider: CXProvider, perform action: CXPlayDTMFCallAction) {
+        NSLog("provider:performPlayDTMFCallAction:")
+
+        if let call = activeCall {
+            call.sendDigits(action.digits)
             action.fulfill()
         } else {
             action.fail()

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -163,8 +163,9 @@ class ViewController: UIViewController {
                 self?.performStartCallAction(uuid: uuid, handle: handle)
                 return
             }
-        
-            self?.showMicrophoneAccessRequest(uuid, handle)
+            DispatchQueue.main.async {
+                self?.showMicrophoneAccessRequest(uuid, handle)
+            }
         }
     }
     
@@ -710,6 +711,17 @@ extension ViewController: CXProviderDelegate {
 
         if let call = activeCalls[action.callUUID.uuidString] {
             call.isMuted = action.isMuted
+            action.fulfill()
+        } else {
+            action.fail()
+        }
+    }
+
+    func provider(_ provider: CXProvider, perform action: CXPlayDTMFCallAction) {
+        NSLog("provider:performPlayDTMFCallAction:")
+
+        if let call = activeCalls[action.callUUID.uuidString] {
+            call.sendDigits(action.digits)
             action.fulfill()
         } else {
             action.fail()


### PR DESCRIPTION
<!-- Describe your Pull Request -->
- Fix an issue when the alert message that is shown when denying the microphone usage permission was not being presented on the main thread, resulting in a crash.
- Add support for sending DTMF via [performPlayDTMFCallAction](https://developer.apple.com/documentation/callkit/cxproviderdelegate/provider(_:perform:)-4htxt?changes=_3&language=objc)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
